### PR TITLE
feat(back): M4 — segment users endpoint, API stabilization, enum Literals, Swagger docs

### DIFF
--- a/pulse/api/routes/ab_tests.py
+++ b/pulse/api/routes/ab_tests.py
@@ -15,7 +15,11 @@ from schema import ABTestSummary, SegmentABComparison
 router = APIRouter(prefix="/api/ab-tests", tags=["ab-tests"])
 
 
-@router.get("/summary", response_model=list[ABTestSummary])
+@router.get("/summary", response_model=list[ABTestSummary],
+            responses={200: {"description": "A/B test results per segment"}})
+
+@router.get("/comparison", response_model=list[SegmentABComparison],
+            responses={200: {"description": "Control vs treatment comparison per segment"}})
 def get_ab_test_summary(db: Session = Depends(get_db)):
     """Cards on the A/B Tests screen — one per segment test.
 

--- a/pulse/api/routes/ab_tests.py
+++ b/pulse/api/routes/ab_tests.py
@@ -18,8 +18,7 @@ router = APIRouter(prefix="/api/ab-tests", tags=["ab-tests"])
 @router.get("/summary", response_model=list[ABTestSummary],
             responses={200: {"description": "A/B test results per segment"}})
 
-@router.get("/comparison", response_model=list[SegmentABComparison],
-            responses={200: {"description": "Control vs treatment comparison per segment"}})
+
 def get_ab_test_summary(db: Session = Depends(get_db)):
     """Cards on the A/B Tests screen — one per segment test.
 
@@ -57,7 +56,8 @@ def get_ab_test_summary(db: Session = Depends(get_db)):
         return []
 
 
-@router.get("/comparison", response_model=list[SegmentABComparison])
+@router.get("/comparison", response_model=list[SegmentABComparison],
+            responses={200: {"description": "Control vs treatment comparison per segment"}})
 def get_ab_comparison(db: Session = Depends(get_db)):
     """Bottom table on the A/B Tests screen.
 

--- a/pulse/api/routes/campaigns.py
+++ b/pulse/api/routes/campaigns.py
@@ -77,7 +77,8 @@ _CAMPAIGNS_SQL = text("""
 
 # ── Campaign CRUD ────────────────────────────────────────────────────
 
-@router.get("/campaigns", response_model=list[CampaignOut])
+@router.get("/campaigns", response_model=list[CampaignOut],
+            responses={200: {"description": "All campaigns with active messages"}})
 def list_campaigns(db: Session = Depends(get_db)):
     """All four campaign cards — one per segment — with their active
     message template attached."""
@@ -97,7 +98,8 @@ def list_campaigns(db: Session = Depends(get_db)):
         return []
 
 
-@router.get("/campaigns/{campaign_id}", response_model=CampaignOut)
+@router.get("/campaigns/{campaign_id}", response_model=CampaignOut,
+            responses={200: {"description": "Single campaign details"}})
 def get_campaign(campaign_id: str, db: Session = Depends(get_db)):
     """Single campaign by ID."""
     row = db.execute(
@@ -124,7 +126,8 @@ def get_campaign(campaign_id: str, db: Session = Depends(get_db)):
     return _build_campaign(row, msg_row)
 
 
-@router.put("/campaigns/{campaign_id}", response_model=CampaignOut)
+@router.put("/campaigns/{campaign_id}", response_model=CampaignOut,
+            responses={200: {"description": "Updated campaign"}})
 def update_campaign(
     campaign_id: str, payload: CampaignUpdate, db: Session = Depends(get_db)
 ):
@@ -149,7 +152,8 @@ def update_campaign(
     return get_campaign(campaign_id, db)
 
 
-@router.put("/campaigns/{campaign_id}/message", response_model=CampaignOut)
+@router.put("/campaigns/{campaign_id}/message", response_model=CampaignOut,
+            responses={200: {"description": "Campaign with updated message body"}})
 def update_message(
     campaign_id: str, payload: MessageUpdate, db: Session = Depends(get_db)
 ):
@@ -177,7 +181,8 @@ def update_message(
     return get_campaign(campaign_id, db)
 
 
-@router.post("/campaigns/{campaign_id}/launch", response_model=CampaignOut)
+@router.post("/campaigns/{campaign_id}/launch", response_model=CampaignOut,
+             responses={200: {"description": "Campaign now running"}})
 def launch_campaign(campaign_id: str, db: Session = Depends(get_db)):
     """Set campaign status to 'running' — the Launch A/B test button."""
     db.execute(
@@ -192,7 +197,9 @@ def launch_campaign(campaign_id: str, db: Session = Depends(get_db)):
     return get_campaign(campaign_id, db)
 
 
-@router.delete("/campaigns/{campaign_id}/reset", response_model=CampaignOut)
+@router.delete("/campaigns/{campaign_id}/reset", response_model=CampaignOut,
+               responses={200: {"description": "Campaign reset to draft"}})
+
 def reset_campaign(campaign_id: str, db: Session = Depends(get_db)):
     """Reset campaign back to 'draft'."""
     db.execute(
@@ -209,7 +216,8 @@ def reset_campaign(campaign_id: str, db: Session = Depends(get_db)):
 
 # ── Global Params ────────────────────────────────────────────────────
 
-@router.get("/global-params", response_model=list[GlobalParamOut])
+@router.get("/global-params", response_model=list[GlobalParamOut],
+            responses={200: {"description": "All global parameters"}})
 def list_global_params(db: Session = Depends(get_db)):
     """All shared Campaign Editor params."""
     try:
@@ -221,7 +229,8 @@ def list_global_params(db: Session = Depends(get_db)):
         return []
 
 
-@router.put("/global-params/{key}", response_model=GlobalParamOut)
+@router.put("/global-params/{key}", response_model=GlobalParamOut,
+            responses={200: {"description": "Updated global parameter"}})
 def update_global_param(
     key: str, payload: GlobalParamUpdate, db: Session = Depends(get_db)
 ):

--- a/pulse/api/routes/demo.py
+++ b/pulse/api/routes/demo.py
@@ -15,7 +15,8 @@ from schema import DemoMessageOut, DemoResponse, DemoRespondResult
 router = APIRouter(prefix="/api/demo", tags=["demo"])
 
 
-@router.get("/message/{segment_name}", response_model=DemoMessageOut)
+@router.get("/message/{segment_name}", response_model=DemoMessageOut,
+            responses={200: {"description": "Rendered upgrade message for the segment"}})
 def get_demo_message(segment_name: str, db: Session = Depends(get_db)):
     """Get the rendered upgrade message for a segment.
 
@@ -68,7 +69,8 @@ def get_demo_message(segment_name: str, db: Session = Depends(get_db)):
     )
 
 
-@router.post("/respond", response_model=DemoRespondResult)
+@router.post("/respond", response_model=DemoRespondResult,
+             responses={200: {"description": "Confirmation that the decision was recorded"}})
 def record_demo_response(payload: DemoResponse, db: Session = Depends(get_db)):
     """Record a user's upgrade / try-later decision from the Demo screen."""
     user = db.execute(

--- a/pulse/api/routes/kpis.py
+++ b/pulse/api/routes/kpis.py
@@ -14,7 +14,8 @@ from schema import PlatformKPIs
 router = APIRouter(prefix="/api/kpis", tags=["kpis"])
 
 
-@router.get("", response_model=PlatformKPIs)
+@router.get("", response_model=PlatformKPIs,
+            responses={200: {"description": "Platform-wide KPI metrics"}})
 def get_platform_kpis(db: Session = Depends(get_db)):
     """Top metric row on the KPIs screen — four numbers.
 

--- a/pulse/api/routes/segments.py
+++ b/pulse/api/routes/segments.py
@@ -10,7 +10,7 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from database import get_db
-from schema import SegmentCount, SegmentBehavioralAvg
+from schema import SegmentCount, SegmentBehavioralAvg, SegmentUserOut
 
 router = APIRouter(prefix="/api/segments", tags=["segments"])
 
@@ -22,7 +22,8 @@ SEGMENT_COLORS = {
 }
 
 
-@router.get("/counts", response_model=list[SegmentCount])
+@router.get("/counts", response_model=list[SegmentCount],
+            responses={200: {"description": "List of segments with user counts"}})
 def get_segment_counts(db: Session = Depends(get_db)):
     """Four KPI cards on the Segments screen.
 
@@ -36,7 +37,8 @@ def get_segment_counts(db: Session = Depends(get_db)):
         return []
 
 
-@router.get("/behavioral-averages", response_model=list[SegmentBehavioralAvg])
+@router.get("/behavioral-averages", response_model=list[SegmentBehavioralAvg],
+            responses={200: {"description": "Average behavioral metrics per segment"}})
 def get_behavioral_averages(db: Session = Depends(get_db)):
     """Bar-chart data on the Segments screen.
 
@@ -59,5 +61,38 @@ def get_behavioral_averages(db: Session = Depends(get_db)):
             )
             for r in rows
         ]
+    except Exception:
+        return []
+
+@router.get("/{name}/users", response_model=list[SegmentUserOut],
+            responses={200: {"description": "Up to 50 users in the given segment"}})
+def get_segment_users(name: str, db: Session = Depends(get_db)):
+    """Drill-down: up to 50 users in the given segment.
+
+    Path parameter `name` must match a segment name exactly
+    (Power, Growing, Casual, Dormant).
+    Queries base tables (users, user_segments, segments) per PM spec.
+    """
+    try:
+        rows = db.execute(
+            text("""
+                SELECT
+                    u.user_id::text,
+                    u.email,
+                    COALESCE(us.feature_session_frequency, 0)    AS sessions_per_week,
+                    COALESCE(u.total_exports, 0)                  AS total_exports,
+                    COALESCE(u.total_paywall_hits, 0)             AS paywall_hits,
+                    COALESCE(u.days_since_last_login, 999)        AS days_since_last_session,
+                    NULL                                           AS predicted_conversion_prob
+                FROM users u
+                JOIN user_segments us ON us.user_id = u.user_id AND us.expires_at IS NULL
+                JOIN segments s       ON s.segment_id = us.segment_id
+                WHERE s.name = :seg_name
+                ORDER BY us.feature_session_frequency DESC NULLS LAST
+                LIMIT 50
+            """),
+            {"seg_name": name},
+        ).mappings().all()
+        return [SegmentUserOut(**r) for r in rows]
     except Exception:
         return []

--- a/pulse/api/routes/segments.py
+++ b/pulse/api/routes/segments.py
@@ -83,7 +83,7 @@ def get_segment_users(name: str, db: Session = Depends(get_db)):
                     COALESCE(u.total_exports, 0)                  AS total_exports,
                     COALESCE(u.total_paywall_hits, 0)             AS paywall_hits,
                     COALESCE(u.days_since_last_login, 999)        AS days_since_last_session,
-                    NULL                                           AS predicted_conversion_prob
+                    NULL                                           AS predicted_conversion_prob  -- TODO: LEFT JOIN user_conversion_scores when DS pipeline populates it
                 FROM users u
                 JOIN user_segments us ON us.user_id = u.user_id AND us.expires_at IS NULL
                 JOIN segments s       ON s.segment_id = us.segment_id

--- a/pulse/api/schema.py
+++ b/pulse/api/schema.py
@@ -31,6 +31,15 @@ class SegmentBehavioralAvg(BaseModel):
     avg_synonym_depth: float | None = None
     avg_exports: float | None = None
 
+class SegmentUserOut(BaseModel):
+    """One user row in the segment drill-down table."""
+    user_id: str
+    email: str
+    sessions_per_week: float
+    total_exports: int
+    paywall_hits: int
+    days_since_last_session: int
+    predicted_conversion_prob: float | None = None
 
 # ═════════════════════════════════════════════════════════════════════
 # A/B TESTS SCREEN
@@ -42,7 +51,7 @@ class ABTestSummary(BaseModel):
     segment_label: str
     color_hex: str
     test_id: str
-    status: str
+    status: Literal['draft', 'pending', 'running', 'paused', 'completed']
     started_at: datetime | None = None
     ended_at: datetime | None = None
     duration_days: int
@@ -55,7 +64,7 @@ class ABTestSummary(BaseModel):
     treatment_rate: float | None = None
     lift_pct: float | None = None
     p_value: float | None = None
-    significance: str | None = None
+    significance: Literal['significant', 'borderline', 'not_significant'] | None = None
     winning_group: str | None = None
 
 
@@ -67,7 +76,7 @@ class SegmentABComparison(BaseModel):
     control_rate: float | None = None
     treatment_rate: float | None = None
     lift_pct: float | None = None
-    significance: str | None = None
+    significance: Literal['significant', 'borderline', 'not_significant'] | None = None
 
 
 # ═════════════════════════════════════════════════════════════════════
@@ -103,9 +112,9 @@ class CampaignOut(BaseModel):
     segment_name: str
     segment_label: str
     color_hex: str
-    channel: str
-    trigger_event: str
-    status: str
+    channel: Literal['in_app_popup', 'push_notification', 'email']
+    trigger_event: Literal['on_paywall_hit', 'on_app_open', 'after_3rd_export']
+    status: Literal['draft', 'pending', 'running', 'paused', 'completed']
     active_message: MessageTemplateOut | None = None
     created_at: datetime
     launched_at: datetime | None = None
@@ -120,8 +129,8 @@ class GlobalParamOut(BaseModel):
 
 class CampaignUpdate(BaseModel):
     """Update the channel and/or trigger of a campaign."""
-    channel: str | None = None
-    trigger_event: str | None = None
+    channel: Literal['in_app_popup', 'push_notification', 'email'] | None = None
+    trigger_event: Literal['on_paywall_hit', 'on_app_open', 'after_3rd_export'] | None = None
 
 
 class MessageUpdate(BaseModel):


### PR DESCRIPTION
## Milestone 4 — Backend

### Changes
- **New endpoint:** `GET /api/segments/{name}/users` — returns up to 50 users in a segment (#114)
- **Schema:** Added `SegmentUserOut` to `schema.py`
- **Enum validation:** Added `Literal` types for `channel`, `trigger_event`, `status`, `significance` in `CampaignOut`, `CampaignUpdate`, `ABTestSummary`, `SegmentABComparison` (#115)
- **Swagger docs:** Added `responses={200: {...}}` descriptions to all 16 endpoints (#115)
- **DB verification:** Confirmed `/api/segments/counts`, `/api/kpis` return live data. `/api/ab-tests/summary` returns `[]` pending DS running `run_ab_analysis.py` (#116)

### Files changed
- `pulse/api/schema.py`
- `pulse/api/routes/segments.py`
- `pulse/api/routes/ab_tests.py`
- `pulse/api/routes/kpis.py`
- `pulse/api/routes/campaigns.py`
- `pulse/api/routes/demo.py`

### Testing
All 17 endpoints tested at localhost:8008/docs — all return 200.

Closes #114, #115, #116. Related: #126.

@silvardanian 